### PR TITLE
Implement MusicBrainz search client

### DIFF
--- a/api_clients/musicbrainz_client.py
+++ b/api_clients/musicbrainz_client.py
@@ -1,0 +1,45 @@
+# coding: utf-8
+"""MusicBrainz API client.
+
+Provides simple wrappers around the MusicBrainz web service for searching
+recordings. This module isolates all MusicBrainz related logic from the rest
+of the application making it easy to replace or extend in the future.
+"""
+
+from typing import List, Dict
+import requests
+
+BASE_URL = "https://musicbrainz.org/ws/2"
+HEADERS = {
+    "User-Agent": "DriveBeats/0.1 ( https://example.com )"
+}
+
+def search_recordings(query: str, limit: int = 20) -> List[Dict]:
+    """Search for recordings on MusicBrainz.
+
+    Parameters
+    ----------
+    query : str
+        Free text search query.
+    limit : int, optional
+        Maximum number of results to return, by default 20.
+
+    Returns
+    -------
+    List[Dict]
+        List of recording dictionaries or an empty list on error.
+    """
+    params = {
+        "query": query,
+        "fmt": "json",
+        "limit": limit,
+    }
+    url = f"{BASE_URL}/recording"
+    try:
+        response = requests.get(url, params=params, headers=HEADERS, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+        return data.get("recordings", [])
+    except requests.RequestException as exc:
+        print(f"MusicBrainz search error: {exc}")
+        return []

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 from database.base_init import initialize_database
 from PySide6 import QtWidgets
 from gui.gui import MusicLoaderApp
-from api_clients.soundcloud_client import search_tracks, get_stream_url
+from api_clients.musicbrainz_client import search_recordings
 from threading import Thread
 from database.db_manager import DatabaseManager
 from download.downloader import TrackDownloader
@@ -24,7 +24,7 @@ def main(db_manager):
 
     # Запуск GUI
     qt_app = QtWidgets.QApplication([])
-    window = MusicLoaderApp(search_tracks, get_stream_url)
+    window = MusicLoaderApp(search_recordings)
     print("Приложение GUI запущено.")
     window.show()
     qt_app.exec()


### PR DESCRIPTION
## Summary
- implement MusicBrainz API client for recording search
- hook GUI search to use MusicBrainz client
- allow adding tracks without stream URLs
- update main entry point to rely on the new client

## Testing
- `python -m py_compile api_clients/musicbrainz_client.py gui/gui.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616cee50fc832e997a9d3e799bb10b