### PR TITLE
Fix duplicate detection with empty URLs

### DIFF
--- a/database/db_manager.py
+++ b/database/db_manager.py
@@ -92,8 +92,16 @@ class DatabaseManager:
                     return False, "duplicate"
 
         # Проверка по URL и названию (если track_id не предоставлен или не найден)
-        cursor.execute(f"SELECT id, file_path, status FROM downloaded_tracks WHERE {url_column} = ? OR (track_title = ? AND artist = ?)",
-                   (download_url, title, artist))
+        if download_url:
+            cursor.execute(
+                f"SELECT id, file_path, status FROM downloaded_tracks WHERE {url_column} = ? OR (track_title = ? AND artist = ?)",
+                (download_url, title, artist),
+            )
+        else:
+            cursor.execute(
+                "SELECT id, file_path, status FROM downloaded_tracks WHERE track_title = ? AND artist = ?",
+                (title, artist),
+            )
         existing = cursor.fetchone()
 
         if existing:


### PR DESCRIPTION
## Summary
- avoid marking new tracks as duplicates when they have no download URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68616f1bea30832ea617ba521c56a2c3