### PR TITLE
Fix Audius search API endpoint

### DIFF
--- a/api_clients/audius_client.py
+++ b/api_clients/audius_client.py
@@ -34,7 +34,7 @@ def _request(endpoint: str, params: Optional[dict] = None) -> dict:
 
 def search_tracks(query: str, limit: int = 20) -> List[Dict]:
     """Search for tracks on Audius by query string."""
-    data = _request("/tracks/search", {"q": query, "limit": limit})
+    data = _request("/search/tracks", {"query": query, "limit": limit})
     return data.get("data", [])
 
 


### PR DESCRIPTION
## Summary
- correct Audius track search path and parameters

## Testing
- `python -m py_compile api_clients/audius_client.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686178eaecb8832ea28bab9154c28e99